### PR TITLE
ci: fix Go installation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20
+        go-version: "1.20"
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
# What this PR changes?

Before this fix, it provided a value for the Go version that YAML parsers interpret in an unexpected way. This PR fixes that issue.